### PR TITLE
Padding was calculated incorrectly in case size was multiple of N_BLO…

### DIFF
--- a/AES.cpp
+++ b/AES.cpp
@@ -247,6 +247,7 @@ AES::AES(){
 	arr_pad[12] = 0x0d;
 	arr_pad[13] = 0x0e;
 	arr_pad[14] = 0x0f;
+	arr_pad[15] = 0x10;
 }
 
 /******************************************************************************/
@@ -485,7 +486,7 @@ void AES::get_IV(byte *out){
 void AES::calc_size_n_pad(int p_size){
 	int s_of_p = p_size - 1;
 	if ( s_of_p % N_BLOCK == 0){
-      size = s_of_p;
+      size = s_of_p + N_BLOCK;;
 	}else{
 		size = s_of_p +  (N_BLOCK-(s_of_p % N_BLOCK));
 	}


### PR DESCRIPTION
…CK. Full block of padding should be used. Instead no padding was applied.