### PR TITLE
Messages passed are byte arrays. There is no hint the array is NULL t…

### DIFF
--- a/AES.cpp
+++ b/AES.cpp
@@ -483,7 +483,7 @@ void AES::get_IV(byte *out){
 /******************************************************************************/
 
 void AES::calc_size_n_pad(int p_size){
-	int s_of_p = p_size - 1;
+	int s_of_p = p_size;
 	if ( s_of_p % N_BLOCK == 0){
       size = s_of_p;
 	}else{


### PR DESCRIPTION
…erminated string. Especially that length is given explicitly. Code should not assume final character is terminator in that case. Due to that substraction of 1 breaks the message (one byte of plaintext is ignored).